### PR TITLE
Update faraday gem

### DIFF
--- a/edge_cast.gemspec
+++ b/edge_cast.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w[CHANGELOG.md LICENSE README.md]
   s.require_path = 'lib'
 
-  s.add_dependency 'faraday',            '~> 0.8'
+  s.add_dependency 'faraday',            '~> 0.9'
   s.add_dependency 'faraday_middleware', '~> 0.8'
   s.add_dependency 'activesupport',      '~> 4.0'
 

--- a/edge_cast.gemspec
+++ b/edge_cast.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w[CHANGELOG.md LICENSE README.md]
   s.require_path = 'lib'
 
-  s.add_dependency 'faraday',            '~> 0.8'
-  s.add_dependency 'faraday_middleware', '~> 0.8'
+  s.add_dependency 'faraday',            '~> 0.9'
   s.add_dependency 'activesupport',      '~> 4.0'
 
   s.add_development_dependency 'rspec',   '~> 2.14'

--- a/edge_cast.gemspec
+++ b/edge_cast.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w[CHANGELOG.md LICENSE README.md]
   s.require_path = 'lib'
 
-  s.add_dependency 'faraday',            '~> 0.9'
+  s.add_dependency 'faraday',            '~> 0.8'
+  s.add_dependency 'faraday_middleware', '~> 0.8'
   s.add_dependency 'activesupport',      '~> 4.0'
 
   s.add_development_dependency 'rspec',   '~> 2.14'

--- a/lib/edge_cast/request/authorization.rb
+++ b/lib/edge_cast/request/authorization.rb
@@ -3,7 +3,7 @@ require 'faraday'
 module EdgeCast
   module Request
     class Authorization < Faraday::Middleware
-      Faraday.register_middleware :request, :auth => lambda { Authorization }
+      Faraday::Request.register_middleware :request, :auth => lambda { Authorization }
 
       def initialize(app, api_token)
         @app, @api_token = app, api_token

--- a/lib/edge_cast/response/raise_client_error.rb
+++ b/lib/edge_cast/response/raise_client_error.rb
@@ -9,7 +9,7 @@ require 'edge_cast/error/unauthorized'
 module EdgeCast
   module Response
     class RaiseClientError < Faraday::Response::Middleware
-      Faraday.register_middleware :response, :client_error => lambda { RaiseClientError }
+      Faraday::Response.register_middleware :response, :client_error => lambda { RaiseClientError }
 
       def on_complete(env)
         case env[:status].to_i

--- a/lib/edge_cast/response/raise_server_error.rb
+++ b/lib/edge_cast/response/raise_server_error.rb
@@ -6,7 +6,7 @@ require 'edge_cast/error/service_unavailable'
 module EdgeCast
   module Response
     class RaiseServerError < Faraday::Response::Middleware
-      Faraday.register_middleware :response, :server_error => lambda { RaiseServerError }
+      Faraday::Response.register_middleware :response, :server_error => lambda { RaiseServerError }
 
       def on_complete(env)
         case env[:status].to_i


### PR DESCRIPTION
Updates to use newer [faraday](https://rubygems.org/gems/faraday_middleware) 0.9
